### PR TITLE
Resolve Dependabot alerts with pnpm overrides and gray-matter patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved 16 Dependabot alerts via pnpm overrides: `dompurify` ^3.2.5, `js-yaml` ^4.2.0, `yaml` ^2.8.4, `launch-editor` ^2.14.1, and `graphiql` ^3.2.0.
 - Patched `gray-matter@4.0.3` to use js-yaml 4 compatible `load`/`dump` APIs.
 - Fixed unescaped double quotes in `src/content/videos/Cmo-crear-tu-staff-digital-con-Gemini.fr.md` frontmatter for js-yaml 4 strict parsing.
+- Regenerated `pnpm-lock.yaml` patch hash to match `patches/gray-matter@4.0.3.patch` and fix frozen installs.
 
 ### Changed
 - Upgraded Astro framework from 5.x to 7.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Resolved 16 Dependabot alerts via pnpm overrides: `dompurify` ^3.2.5, `js-yaml` ^4.2.0, `yaml` ^2.8.4, `launch-editor` ^2.14.1, and `graphiql` ^3.2.0.
+- Patched `gray-matter@4.0.3` to use js-yaml 4 compatible `load`/`dump` APIs.
+- Fixed unescaped double quotes in `src/content/videos/Cmo-crear-tu-staff-digital-con-Gemini.fr.md` frontmatter for js-yaml 4 strict parsing.
+
 ### Changed
 - Upgraded Astro framework from 5.x to 7.0.0.
 - Upgraded `@astrojs/mdx` to 7.0.0, `@astrojs/react` to 6.0.0, `@vitejs/plugin-react` to 6.0.3, `vite` to 8.1.0, `@astrojs/markdown-remark` to 7.2.0, and `marked` to 18.0.5.

--- a/package.json
+++ b/package.json
@@ -77,17 +77,23 @@
   },
   "pnpm": {
     "overrides": {
-      "dompurify": "^2.5.4",
+      "dompurify": "^3.2.5",
       "mermaid": "^10.9.3",
       "jsonpath-plus": "^10.2.0",
       "esbuild": "^0.25.0",
-      "js-yaml": "^3.14.2",
+      "js-yaml": "^4.2.0",
       "mdast-util-to-hast": "^13.2.1",
       "qs": "^6.14.1",
       "react-router": "^6.30.2",
       "diff": "^5.2.2",
       "lodash": "^4.17.23",
-      "lodash-es": "^4.17.23"
+      "lodash-es": "^4.17.23",
+      "yaml": "^2.8.4",
+      "launch-editor": "^2.14.1",
+      "graphiql": "^3.2.0"
+    },
+    "patchedDependencies": {
+      "gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch"
     }
   },
   "devDependencies": {

--- a/patches/gray-matter@4.0.3.patch
+++ b/patches/gray-matter@4.0.3.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/engines.js b/lib/engines.js
+index 38f993db06cf364191ac635a6590c2d29303297d..1dfec8d9527653ad9ccfaacfa59732246fdb1e32 100644
+--- a/lib/engines.js
++++ b/lib/engines.js
+@@ -13,8 +13,8 @@ const engines = exports = module.exports;
+  */
+ 
+ engines.yaml = {
+-  parse: yaml.safeLoad.bind(yaml),
+-  stringify: yaml.safeDump.bind(yaml)
++  parse: yaml.load.bind(yaml),
++  stringify: yaml.dump.bind(yaml)
+ };
+ 
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,17 +5,25 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify: ^2.5.4
+  dompurify: ^3.2.5
   mermaid: ^10.9.3
   jsonpath-plus: ^10.2.0
   esbuild: ^0.25.0
-  js-yaml: ^3.14.2
+  js-yaml: ^4.2.0
   mdast-util-to-hast: ^13.2.1
   qs: ^6.14.1
   react-router: ^6.30.2
   diff: ^5.2.2
   lodash: ^4.17.23
   lodash-es: ^4.17.23
+  yaml: ^2.8.4
+  launch-editor: ^2.14.1
+  graphiql: ^3.2.0
+
+patchedDependencies:
+  gray-matter@4.0.3:
+    hash: 6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188
+    path: patches/gray-matter@4.0.3.patch
 
 importers:
 
@@ -59,7 +67,7 @@ importers:
         version: 13.0.6
       gray-matter:
         specifier: ^4.0.3
-        version: 4.0.3
+        version: 4.0.3(patch_hash=6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188)
       marked:
         specifier: ^18.0.5
         version: 18.0.5
@@ -840,12 +848,21 @@ packages:
     resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
     engines: {node: '>=18.0.0'}
 
-  '@graphiql/react@0.18.0':
-    resolution: {integrity: sha512-OIzUjnxBM4k9DY0DXBMRfU+fTak2tbnmY2o6J5t/vKvqGaa4opRUhgIZEvrerjnktjCxj2dJY706gCwnUZQsNg==}
+  '@graphiql/react@0.29.0':
+    resolution: {integrity: sha512-4Zd57+DeK5t1KYiqy9hnuaQhR8fnZ1CkKUkmZqINpAe0OlpbszOE661zwNGuW5NjbXgepfI89ICnh1ZVinSJvg==}
     peerDependencies:
-      graphql: ^15.5.0 || ^16.0.0
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
+
+  '@graphiql/toolkit@0.11.3':
+    resolution: {integrity: sha512-Glf0fK1cdHLNq52UWPzfSrYIJuNxy8h4451Pw1ZVpJ7dtU+tm7GVVC64UjEDQ/v2j3fnG4cX8jvR75IvfL6nzQ==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      graphql-ws: '>= 4.5.0'
+    peerDependenciesMeta:
+      graphql-ws:
+        optional: true
 
   '@graphiql/toolkit@0.8.4':
     resolution: {integrity: sha512-cFUGqh3Dau+SD3Vq9EFlZrhzYfaHKyOJveFtaCR+U5Cn/S68p7oy+vQBIdwtO6J2J58FncnwBbVRfr+IvVfZqQ==}
@@ -2498,6 +2515,9 @@ packages:
   '@types/tern@0.23.9':
     resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2897,9 +2917,6 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -3634,8 +3651,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@2.5.9:
-    resolution: {integrity: sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3694,9 +3711,6 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
-  entities@2.1.0:
-    resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
-
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -3754,11 +3768,6 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -3983,6 +3992,10 @@ packages:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
 
+  get-value@3.0.1:
+    resolution: {integrity: sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==}
+    engines: {node: '>=6.0'}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
@@ -4012,10 +4025,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphiql@3.0.0-alpha.1:
-    resolution: {integrity: sha512-YAL7wQtbC/RkFkjS3SNGzAhwcpYLGC+rZmFu11+/Aa3aXW4Nvi4PIjAIsN4SheEXTyT20QNdFu6B63/3IWmCnA==}
+  graphiql@3.9.0:
+    resolution: {integrity: sha512-rJYFlHdBbug9+YbFSwRVvgfPjCayC7wHecZkx/qB4XLuQPFQZw/yB9pmHFtOJV6RiNBBHro3u1GdocKa3YcGRA==}
     peerDependencies:
-      graphql: ^15.5.0 || ^16.0.0
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
 
@@ -4402,8 +4415,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -4574,9 +4587,6 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@3.0.3:
-    resolution: {integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==}
-
   linkify-it@5.0.1:
     resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
@@ -4653,10 +4663,6 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
-
-  markdown-it@12.3.2:
-    resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
-    hasBin: true
 
   markdown-it@14.2.0:
     resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
@@ -4796,9 +4802,6 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
-
-  mdurl@1.0.1:
-    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -5429,7 +5432,7 @@ packages:
       jiti: '>=1.21.0'
       postcss: '>=8.0.9'
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.4
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -5593,6 +5596,11 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  react-compiler-runtime@19.1.0-rc.1:
+    resolution: {integrity: sha512-wCt6g+cRh8g32QT18/9blfQHywGjYu+4FlEc3CW1mx3pPxYzZZl1y+VtqxRgnKKBCFLIGUYxog4j4rs5YS86hw==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental
 
   react-datetime@3.3.1:
     resolution: {integrity: sha512-CMgQFLGidYu6CAlY6S2Om2UZiTfZsjC6j4foXcZ0kb4cSmPomdJ2S1PhK0v3fwflGGVuVARGxwkEUWtccHapJA==}
@@ -6140,9 +6148,6 @@ packages:
   sponge-case@2.0.3:
     resolution: {integrity: sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   sqlite-level@2.1.1:
     resolution: {integrity: sha512-hhRnO7R4fym5PjWiRkKyMju1Ok6B3MfK3wWyyoeAaGd9OZPrTqGbjEbghHLh7uco4r3syZrbk3/9IQTWCv3/sw==}
 
@@ -6446,9 +6451,6 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uc.micro@1.0.6:
-    resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
@@ -6767,7 +6769,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.4
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -7021,11 +7023,6 @@ packages:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
     hasBin: true
 
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -7232,7 +7229,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.2.0
@@ -7810,9 +7807,9 @@ snapshots:
 
   '@google/generative-ai@0.24.1': {}
 
-  '@graphiql/react@0.18.0(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@graphiql/react@0.29.0(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@graphiql/toolkit': 0.8.4(@types/node@24.13.2)(graphql@15.8.0)
+      '@graphiql/toolkit': 0.11.3(@types/node@24.13.2)(graphql@15.8.0)
       '@headlessui/react': 1.7.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dropdown-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7824,10 +7821,12 @@ snapshots:
       codemirror-graphql: 2.2.7(@codemirror/language@6.0.0)(codemirror@5.65.21)(graphql@15.8.0)
       copy-to-clipboard: 3.3.3
       framer-motion: 6.5.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      get-value: 3.0.1
       graphql: 15.8.0
       graphql-language-service: 5.5.2(graphql@15.8.0)
-      markdown-it: 12.3.2
+      markdown-it: 14.2.0
       react: 19.2.7
+      react-compiler-runtime: 19.1.0-rc.1(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
       set-value: 4.1.0
     transitivePeerDependencies:
@@ -7836,6 +7835,14 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - graphql-ws
+
+  '@graphiql/toolkit@0.11.3(@types/node@24.13.2)(graphql@15.8.0)':
+    dependencies:
+      '@n1ru4l/push-pull-async-iterable-iterator': 3.2.0
+      graphql: 15.8.0
+      meros: 1.3.2(@types/node@24.13.2)
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@graphiql/toolkit@0.8.4(@types/node@24.13.2)(graphql@15.8.0)':
     dependencies:
@@ -9294,7 +9301,7 @@ snapshots:
       '@monaco-editor/react': 4.7.0-rc.0(monaco-editor@0.31.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tinacms/mdx': 2.1.7(react@19.2.7)(typescript@5.9.3)(yup@1.7.1)
       final-form: 4.20.10
-      graphiql: 3.0.0-alpha.1(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      graphiql: 3.9.0(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       graphql: 15.8.0
       monaco-editor: 0.31.0
       react: 19.2.7
@@ -9359,7 +9366,7 @@ snapshots:
       esbuild: 0.25.12
       fs-extra: 11.3.5
       graphql: 15.8.0
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       many-level: 2.0.0
       memory-level: 1.0.0
       minimatch: 5.1.9
@@ -9418,10 +9425,10 @@ snapshots:
       fs-extra: 11.3.5
       glob-parent: 6.0.2
       graphql: 15.8.0
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188)
       isomorphic-git: 1.38.5
       js-sha1: 0.6.0
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       jsonpath-plus: 10.4.0
       many-level: 2.0.0
       micromatch: 4.0.8
@@ -9617,6 +9624,9 @@ snapshots:
   '@types/tern@0.23.9':
     dependencies:
       '@types/estree': 1.0.9
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -10120,10 +10130,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -10180,7 +10186,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
@@ -10587,7 +10593,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -10938,7 +10944,9 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@2.5.9: {}
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -10992,8 +11000,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
-
-  entities@2.1.0: {}
 
   entities@4.5.0: {}
 
@@ -11069,8 +11075,6 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@5.0.0: {}
-
-  esprima@4.0.1: {}
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -11344,6 +11348,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-value@3.0.1:
+    dependencies:
+      isobject: 3.0.1
+
   github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
@@ -11375,14 +11383,12 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphiql@3.0.0-alpha.1(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  graphiql@3.9.0(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@graphiql/react': 0.18.0(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@graphiql/toolkit': 0.8.4(@types/node@24.13.2)(graphql@15.8.0)
+      '@graphiql/react': 0.29.0(@codemirror/language@6.0.0)(@types/node@24.13.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(graphql@15.8.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       graphql: 15.8.0
-      graphql-language-service: 5.5.2(graphql@15.8.0)
-      markdown-it: 12.3.2
       react: 19.2.7
+      react-compiler-runtime: 19.1.0-rc.1(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@codemirror/language'
@@ -11405,9 +11411,9 @@ snapshots:
 
   graphql@15.8.0: {}
 
-  gray-matter@4.0.3:
+  gray-matter@4.0.3(patch_hash=6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188):
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -11816,10 +11822,9 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@4.2.0:
     dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
+      argparse: 2.0.1
 
   jsdom@29.1.1:
     dependencies:
@@ -11959,10 +11964,6 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@3.0.3:
-    dependencies:
-      uc.micro: 1.0.6
-
   linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
@@ -12040,14 +12041,6 @@ snapshots:
   map-cache@0.2.2: {}
 
   markdown-extensions@2.0.0: {}
-
-  markdown-it@12.3.2:
-    dependencies:
-      argparse: 2.0.1
-      entities: 2.1.0
-      linkify-it: 3.0.3
-      mdurl: 1.0.1
-      uc.micro: 1.0.6
 
   markdown-it@14.2.0:
     dependencies:
@@ -12436,8 +12429,6 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mdurl@1.0.1: {}
-
   mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
@@ -12463,7 +12454,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.21
-      dompurify: 2.5.9
+      dompurify: 3.4.11
       elkjs: 0.9.3
       katex: 0.16.47
       khroma: 2.1.0
@@ -13422,7 +13413,7 @@ snapshots:
       '@posthog/core': 1.36.0
       '@posthog/types': 1.391.0
       core-js: 3.49.0
-      dompurify: 2.5.9
+      dompurify: 3.4.11
       fflate: 0.4.8
       preact: 10.29.2
       query-selector-shadow-dom: 1.0.1
@@ -13566,6 +13557,10 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  react-compiler-runtime@19.1.0-rc.1(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   react-datetime@3.3.1(moment@2.29.4)(react@19.2.7):
     dependencies:
@@ -14402,8 +14397,6 @@ snapshots:
 
   sponge-case@2.0.3: {}
 
-  sprintf-js@1.0.3: {}
-
   sqlite-level@2.1.1:
     dependencies:
       abstract-level: 1.0.4
@@ -14815,8 +14808,6 @@ snapshots:
       semver: 7.8.5
 
   typescript@5.9.3: {}
-
-  uc.micro@1.0.6: {}
 
   uc.micro@2.1.0: {}
 
@@ -15301,9 +15292,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
 
 patchedDependencies:
   gray-matter@4.0.3:
-    hash: 6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188
+    hash: 82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f
     path: patches/gray-matter@4.0.3.patch
 
 importers:
@@ -67,7 +67,7 @@ importers:
         version: 13.0.6
       gray-matter:
         specifier: ^4.0.3
-        version: 4.0.3(patch_hash=6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188)
+        version: 4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f)
       marked:
         specifier: ^18.0.5
         version: 18.0.5
@@ -9425,7 +9425,7 @@ snapshots:
       fs-extra: 11.3.5
       glob-parent: 6.0.2
       graphql: 15.8.0
-      gray-matter: 4.0.3(patch_hash=6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188)
+      gray-matter: 4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f)
       isomorphic-git: 1.38.5
       js-sha1: 0.6.0
       js-yaml: 4.2.0
@@ -11411,7 +11411,7 @@ snapshots:
 
   graphql@15.8.0: {}
 
-  gray-matter@4.0.3(patch_hash=6867093d18e007f9f610b1c4c6871b64734503b546ffcd3bc7a3675dd11f2188):
+  gray-matter@4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f):
     dependencies:
       js-yaml: 4.2.0
       kind-of: 6.0.3

--- a/src/content/videos/Cmo-crear-tu-staff-digital-con-Gemini.fr.md
+++ b/src/content/videos/Cmo-crear-tu-staff-digital-con-Gemini.fr.md
@@ -2,7 +2,7 @@
 title: Comment créer votre équipe numérique avec Gemini
 videoId: _oYKaBO75nU
 date: 2026-01-27T00:00:00.000Z
-description: "De nombreux entrepreneurs estiment que la technologie complique plus qu'elle n'aide. Dans cette vidéo, je vous montre comment passer de la simple "discussion" avec l'intelligence artificielle à la construction d'une équipe numérique qui vous assiste réellement dans vos tâches quotidiennes. Nous allons configurer trois assistants spécialisés qui travaillent avec vos propres informations et documents, vous permettant ainsi d'accroître votre productivité au coût le plus bas possible.\n\n\U0001F680 Ce que vous apprendrez dans cette vidéo :\nConfiguration d'Experts : Comment utiliser les Gemmes de Gemini pour créer des profils avec des rôles, des règles et des comportements spécifiques."
+description: "De nombreux entrepreneurs estiment que la technologie complique plus qu'elle n'aide. Dans cette vidéo, je vous montre comment passer de la simple \"discussion\" avec l'intelligence artificielle à la construction d'une équipe numérique qui vous assiste réellement dans vos tâches quotidiennes. Nous allons configurer trois assistants spécialisés qui travaillent avec vos propres informations et documents, vous permettant ainsi d'accroître votre productivité au coût le plus bas possible.\n\n\U0001F680 Ce que vous apprendrez dans cette vidéo :\nConfiguration d'Experts : Comment utiliser les Gemmes de Gemini pour créer des profils avec des rôles, des règles et des comportements spécifiques."
 featured: true
 ---
 


### PR DESCRIPTION
- Upgraded dompurify, js-yaml, yaml, launch-editor, and graphiql via overrides
- Patched gray-matter@4.0.3 to use js-yaml 4 load/dump APIs
- Fixed unescaped double quotes in French video frontmatter
